### PR TITLE
Update deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,21 +43,21 @@ references:
     &test_config
     docker:
       - image: cimg/clojure:1.11
-      - image: confluentinc/cp-zookeeper:6.1.1
+      - image: confluentinc/cp-zookeeper:6.2.4
         environment:
           ZOOKEEPER_CLIENT_PORT: 2181
-      - image: confluentinc/cp-kafka:6.1.1
+      - image: confluentinc/cp-kafka:6.2.4
         environment:
           KAFKA_BROKER_ID: 1
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
           KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-      - image: confluentinc/cp-schema-registry:6.1.1
+      - image: confluentinc/cp-schema-registry:6.2.4
         environment:
           SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: localhost:2181
           SCHEMA_REGISTRY_HOST_NAME: localhost
           SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
-      - image: confluentinc/cp-kafka-rest:6.1.1
+      - image: confluentinc/cp-kafka-rest:6.2.4
         environment:
           KAFKA_REST_ZOOKEEPER_CONNECT: localhost:2181
           KAFKA_REST_BOOTSTRAP_SERVERS: localhost:9092

--- a/project.clj
+++ b/project.clj
@@ -7,38 +7,38 @@
 
   :repositories [["confluent" {:url "https://packages.confluent.io/maven/"}]]
 
-  :dependencies [[aleph "0.4.6"]
+  :dependencies [[aleph "0.4.7"]
                  [danlentz/clj-uuid "0.1.9"
                   :exclusions [primitive-math]]
 
                  ;; Confluent does paired releases with Kafka, this should tie
                  ;; off with the kafka version.
                  ;; See https://docs.confluent.io/current/release-notes.html
-                 [io.confluent/kafka-schema-registry-client "6.1.1"
+                 [io.confluent/kafka-schema-registry-client "6.2.4"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [io.confluent/kafka-avro-serializer "6.1.1"]
-                 [io.confluent/kafka-json-schema-serializer "6.1.1"]
-                 [org.apache.kafka/kafka-clients "2.8.0"]
-                 [org.apache.kafka/kafka-streams "2.8.0"]
-                 [org.apache.kafka/kafka-streams-test-utils "2.8.0"]
+                 [io.confluent/kafka-avro-serializer "6.2.4"]
+                 [io.confluent/kafka-json-schema-serializer "6.2.4"]
+                 [org.apache.kafka/kafka-clients "2.8.1"]
+                 [org.apache.kafka/kafka-streams "2.8.1"]
+                 [org.apache.kafka/kafka-streams-test-utils "2.8.1"]
 
-                 [org.clojure/clojure "1.10.1" :scope "provided"]
-                 [org.clojure/data.json "0.2.6"]
-                 [org.clojure/data.fressian "0.2.1"]
-                 [org.clojure/tools.logging "0.4.1"]
-                 [org.clojure/core.cache "0.7.2"]
-                 [metosin/jsonista "0.3.3"]
+                 [org.clojure/clojure "1.11.1" :scope "provided"]
+                 [org.clojure/data.json "2.4.0"]
+                 [org.clojure/data.fressian "1.0.0"]
+                 [org.clojure/tools.logging "1.2.4"]
+                 [org.clojure/core.cache "1.0.225"]
+                 [metosin/jsonista "0.3.5"]
 
                  ;; Use specific netty version to avoid critical CVE
                  ;; pulled by Aleph v0.4.6 (last stable version)
-                 [io.netty/netty-transport "4.1.68.Final"]
-                 [io.netty/netty-transport-native-epoll "4.1.68.Final"]
-                 [io.netty/netty-codec "4.1.68.Final"]
-                 [io.netty/netty-codec-http "4.1.68.Final"]
-                 [io.netty/netty-handler "4.1.68.Final"]
-                 [io.netty/netty-handler-proxy "4.1.68.Final"]
-                 [io.netty/netty-resolver "4.1.68.Final"]
-                 [io.netty/netty-resolver-dns "4.1.68.Final"]
+                 [io.netty/netty-transport "4.1.77.Final"]
+                 [io.netty/netty-transport-native-epoll "4.1.77.Final"]
+                 [io.netty/netty-codec "4.1.77.Final"]
+                 [io.netty/netty-codec-http "4.1.77.Final"]
+                 [io.netty/netty-handler "4.1.77.Final"]
+                 [io.netty/netty-handler-proxy "4.1.77.Final"]
+                 [io.netty/netty-resolver "4.1.77.Final"]
+                 [io.netty/netty-resolver-dns "4.1.77.Final"]
 
                  ;; Use specific commons-compress version to avoid
                  ;; CVE-2021-36090 pulled by avro 1.9.2
@@ -86,14 +86,14 @@
 
               :resource-paths ["test/resources"]
               :injections [(require 'io.aviso.logging.setup)]
-              :dependencies [[io.aviso/logging "0.3.2"]
-                             [org.apache.kafka/kafka-streams-test-utils "2.8.0"]
-                             [org.apache.kafka/kafka-clients "2.8.0" :classifier "test"]
-                             [org.clojure/test.check "0.9.0"]
-                             [org.apache.kafka/kafka_2.13 "2.8.0"]
-                             [lambdaisland/kaocha "0.0-529"]
-                             [lambdaisland/kaocha-cloverage "0.0-32"]
-                             [lambdaisland/kaocha-junit-xml "0.0-70"]]}
+              :dependencies [[io.aviso/logging "1.0"]
+                             [org.apache.kafka/kafka-streams-test-utils "2.8.1"]
+                             [org.apache.kafka/kafka-clients "2.8.1" :classifier "test"]
+                             [org.clojure/test.check "1.1.1"]
+                             [org.apache.kafka/kafka_2.13 "2.8.1"]
+                             [lambdaisland/kaocha "1.66.1034"]
+                             [lambdaisland/kaocha-cloverage "1.0.75"]
+                             [lambdaisland/kaocha-junit-xml "0.0.76"]]}
 
              ;; This is not in fact what lein defines repl to be
              :repl


### PR DESCRIPTION
Hold kafka back to 2.8.x / confluent 6.2.x

Signed-off-by: Greg Haskins <greg@manetu.com>

# Checklist

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
